### PR TITLE
Updates standalone.el so it can run in non-GUI mode

### DIFF
--- a/standalone.el
+++ b/standalone.el
@@ -43,7 +43,8 @@
 
 (tool-bar-mode 0)
 (menu-bar-mode 0)
-(scroll-bar-mode 0)
+(when (fboundp 'scroll-bar-mode)
+  (scroll-bar-mode 0))
 
 (cond
  ((member "Monaco" (font-family-list))


### PR DESCRIPTION
The function `scroll-bar-mode` is not present when emacs is running in
tty mode. This edit verifies it’s present before trying to run it, so that this
can run in a terminal without a GUI.

I have verified that with this change, standalone.el runs to completion without leaving errors in the *Messages* buffer, on Ubuntu 20.04 running emacs 27.1.

(I have not verified that all emacs-rust-config functionality is working in this setting.)